### PR TITLE
Update SASS image

### DIFF
--- a/sass/Dockerfile
+++ b/sass/Dockerfile
@@ -1,5 +1,4 @@
-FROM debian:wheezy
-
-ADD https://dl.dropboxusercontent.com/u/92733564/sassc /usr/bin/sass
-RUN chmod +x /usr/bin/sass
+FROM alpine:3.1
+ADD build.sh /usr/bin/
+RUN build.sh
 ENTRYPOINT [ "sass" ]

--- a/sass/README.md
+++ b/sass/README.md
@@ -2,24 +2,35 @@
 
 SASS/SCSS compiler
 
-* built on top of `debian` base image
+* built on top of `alpine` base image
 * uses [sassc](https://github.com/sass/sassc)
-* ~88 MB in size (85 MB debian base + 3 MB sassc binary)
-* invoke with `docker run --rm -v $(pwd):$(pwd) -w $(pwd) jbergknoff/sass file.scss`
+* ~9 MB in size (5 MB alpine base + 4 MB sassc binary)
+
+## Usage
+
+The image has the `sass` binary as its entrypoint, so it should be invoked with whatever arguments you would normally pass to sass. For example,
+
+```bash
+$ cat file.scss
+$blue: #00f;
+.thing { color: $blue; }
+$ docker run --rm -v $(pwd):$(pwd) -w $(pwd) jbergknoff/sass file.scss
+.thing {
+  color: #00f; }
+```
+
+You may also want to create a bash alias:
+
+```bash
+alias sass="docker run -it --rm -v \$(pwd):\$(pwd) -w \$(pwd) jbergknoff/sass"
+```
+
+so you will be able to simply run
+
+```
+sass file.scss
+```
 
 ## Generating the binary
 
-I compiled the `sassc` binary in a docker container and then uploaded it to dropbox in order to keep this image as small as possible (i.e. excluding the build tools). The procedure was as follows:
-
-```
-HOST
-$ git clone git@github.com:sass/sassc
-$ cd sassc && git clone git@github.com:sass/libsass
-$ docker run -it --rm -v $(pwd):/sass debian:wheezy
-CONTAINER
-# apt-get update && apt-get install -y build-essential
-# cd sass
-# SASS_LIBSASS_PATH=/sass/libsass make
-```
-
-At this point, the binary is located on the host at `$(pwd)/bin/sassc`.
+The binary is compiled as part of the Dockerfile, and the build tools are subsequently removed.

--- a/sass/README.md
+++ b/sass/README.md
@@ -28,7 +28,9 @@ alias sass="docker run -it --rm -v \$(pwd):\$(pwd) -w \$(pwd) jbergknoff/sass"
 so you will be able to simply run
 
 ```
-sass file.scss
+$ sass file.scss
+.thing {
+  color: #00f; }
 ```
 
 ## Generating the binary

--- a/sass/build.sh
+++ b/sass/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# build
+apk --update add git build-base
+git clone https://github.com/sass/sassc
+cd sassc
+git clone https://github.com/sass/libsass
+SASS_LIBSASS_PATH=/sassc/libsass make
+
+# install
+mv bin/sassc /usr/bin/sass
+
+# cleanup
+cd /
+rm -rf /sassc
+apk del git build-base
+apk add libstdc++ # sass binary still needs this because of dynamic linking.
+rm -rf /var/cache/apk/*


### PR DESCRIPTION
Improvements to the SASS image: based off of alpine for 9 MB image size (down from 88 MB), and built from source as part of Dockerfile, rather than adding a scary-looking binary from dropbox.
