### PR TITLE
Upgrade s3rever to support dots in bucket names; upgrade node to support s3rver v2

### DIFF
--- a/s3rver/Dockerfile
+++ b/s3rver/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:5.3.0 
-RUN npm install -g s3rver@0.0.12
+FROM mhart/alpine-node:6.13.1
+RUN npm install -g s3rver@2.2.1
 EXPOSE 5000
 CMD [ "s3rver", "--hostname", "0.0.0.0", "--port", "5000", "--directory", "/tmp" ]


### PR DESCRIPTION
Newer versions of s3rver support a similar range of bucket names as s3, including names with dots in them. This upgraded s3rver requires at least node v6.